### PR TITLE
Added after reduce code

### DIFF
--- a/cup/parser.cup
+++ b/cup/parser.cup
@@ -600,6 +600,8 @@ symbol_id ::=
 	| LEFT
 	| RIGHT
 	| NONASSOC
+	| AFTER
+	| REDUCE
 	;
 
 /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */ 
@@ -623,6 +625,8 @@ robust_id ::= /* all ids that aren't reserved words in Java */
 	| LEFT
 	| RIGHT
 	| NONASSOC
+	| AFTER
+	| REDUCE
 	| error
 	{:
 		ErrorManager.getManager().emit_error("Illegal use of reserved word");

--- a/cup/parser.cup
+++ b/cup/parser.cup
@@ -198,20 +198,20 @@ terminal
 terminal String
   PACKAGE, IMPORT, CODE, ACTION, PARSER, TERMINAL, NON, NONTERMINAL, INIT, 
   SCAN, WITH, START, PRECEDENCE, LEFT, RIGHT, NONASSOC, SUPER, EXTENDS, 
-  OPTION;
+  AFTER, REDUCE, OPTION;
 
 terminal String  ID, CODE_STRING;
 
 non terminal
   package_spec, parser_spec,
-  option_spec, option_list, option_, action_code_part, 
-  code_parts, code_part, 
-  parser_code_part, start_spec, 
-  import_spec, init_code, scan_code, symbol, 
-  terminal_non_terminal, decl_symbol_list, new_symbol_id,  
+  option_spec, option_list, option_, action_code_part,
+  code_parts, code_part,
+  parser_code_part, start_spec,
+  import_spec, init_code, scan_code, after_reduce_code, symbol,
+  terminal_non_terminal, decl_symbol_list, new_symbol_id,
   preced, assoc, precterminal_list, precterminal_id,
   production, rhs_list, rhs;
-  
+
 non terminal Grammar spec;
 
 non terminal String  symbol_id, label_id, robust_id;
@@ -220,15 +220,15 @@ non terminal StringBuilder multipart_id, import_id, type_id,
 non terminal symbol wild_symbol_id;
 
 non terminal production_part prod_part;
-non terminal symbol prod_precedence; 
+non terminal symbol prod_precedence;
 
-/*----------------------------------------------------------------*/ 
+/*----------------------------------------------------------------*/
 
 start with spec;
 
-/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */ 
+/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */
 
-spec ::= 
+spec ::=
 	package_spec
 	import_spec*
 	code_parts
@@ -238,12 +238,12 @@ spec ::=
 	production+
         {: RESULT = grammar; :}
 	|
-	/* error recovery assuming something went wrong before symbols 
+	/* error recovery assuming something went wrong before symbols
 	   and we have TERMINAL or NON TERMINAL to sync on.  if we get
-	   an error after that, we recover inside symbol_list or 
-	   production_list 
+	   an error after that, we recover inside symbol_list or
+	   production_list
 	*/
-	error 
+	error
 	symbol+
 	preced*
 	start_spec
@@ -251,9 +251,9 @@ spec ::=
         {: RESULT = grammar; :}
 	;
 
-/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */ 
+/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */
 
-package_spec ::= 
+package_spec ::=
 	PACKAGE	multipart_id:id SEMI
 	{:
 	  /* save the package name */
@@ -263,11 +263,11 @@ package_spec ::=
 	/* empty */
 	;
 
-/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */ 
+/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */
 
 import_spec ::=
 	IMPORT import_id:id SEMI
-	{: 
+	{:
 	  /* save this import on the imports list */
 	  parser.emit.import_list.add(id.toString());
 	:}
@@ -278,13 +278,13 @@ import_spec ::=
 // (we check in the part action to make sure we don't have 2 of any part)
 code_part ::=
     option_spec | parser_spec |
-	action_code_part | parser_code_part | init_code | scan_code ;
-code_parts ::= 
+	action_code_part | parser_code_part | init_code | scan_code | after_reduce_code;
+code_parts ::=
 	| code_parts code_part;
 
-/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */ 
+/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */
 
-parser_spec ::= 
+parser_spec ::=
 	  PARSER multipart_id:name SEMI
          {: parser.main.setOption("parser", name.toString()); :}
 	| PARSER multipart_id:name LT typearglist:types GT SEMI
@@ -295,12 +295,12 @@ parser_spec ::=
 
 option_spec ::= OPTION option_list SEMI;
 option_list ::= option_list COMMA option_ | option_;
-option_ ::= robust_id:opt {: parser.main.setOption(opt); :} 
+option_ ::= robust_id:opt {: parser.main.setOption(opt); :}
 	| robust_id:opt EQUALS robust_id:val
           {: parser.main.setOption(opt, val); :};
-/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */ 
+/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */
 
-action_code_part ::= 
+action_code_part ::=
 	ACTION CODE CODE_STRING:user_code SEMI?
 	{:
 	  if (parser.emit.action_code!=null)
@@ -310,9 +310,9 @@ action_code_part ::=
 	:}
 	;
 
-/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */ 
+/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */
 
-parser_code_part ::= 
+parser_code_part ::=
 	PARSER CODE CODE_STRING:user_code SEMI?
 	{:
 	  if (parser.emit.parser_code!=null)
@@ -322,11 +322,11 @@ parser_code_part ::=
 	:}
 	;
 
-/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */ 
+/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */
 
-init_code ::= 
+init_code ::=
 	INIT WITH CODE_STRING:user_code SEMI?
-	{: 
+	{:
 	  if (parser.emit.init_code!=null)
 	    ErrorManager.getManager().emit_warning("Redundant init code (skipping)");
 	  else /* save the user code */
@@ -334,15 +334,27 @@ init_code ::=
 	:}
 	;
 
-/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */ 
+/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */
 
 scan_code ::=
 	SCAN WITH CODE_STRING:user_code SEMI?
-	{: 
+	{:
 	  if (parser.emit.scan_code!=null)
 	    ErrorManager.getManager().emit_warning("Redundant scan code (skipping)");
 	  else /* save the user code */
 	    parser.emit.scan_code = user_code;
+	:}
+	;
+
+/*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . */
+
+after_reduce_code ::=
+	AFTER REDUCE CODE_STRING:user_code SEMI?
+	{:
+	  if (parser.emit.after_reduce_code!=null)
+	    ErrorManager.getManager().emit_warning("Redundant after reduce code (skipping)");
+	  else /* save the user code */
+	    parser.emit.after_reduce_code = user_code;
 	:}
 	;
 

--- a/flex/Lexer.jflex
+++ b/flex/Lexer.jflex
@@ -100,6 +100,8 @@ ident = ([:jletter:] | "_" ) ([:jletterdigit:] | [:jletter:] | "_" )*
   "nonassoc"    { return symbol("NONASSOC",NONASSOC,yytext()); }
   "extends"     { return symbol("EXTENDS",EXTENDS,yytext());   }
   "super"       { return symbol("SUPER",SUPER,yytext());       }
+  "after"       { return symbol("AFTER",AFTER,yytext());       }
+  "reduce"      { return symbol("REDUCE",REDUCE,yytext());     }
   {ident}       { return symbol("ID",ID,yytext());             }
   
 }

--- a/src/com/github/jhoenicke/javacup/emit.java
+++ b/src/com/github/jhoenicke/javacup/emit.java
@@ -82,7 +82,7 @@ import java.util.Date;
    init_code               - user supplied code to be executed as the parser 
 			     is being initialized.
    scan_code               - user supplied code to get the next Symbol.
-   after_reduce_code       - user code that will run after every reduce
+   after_reduce_code       - user code that will run after every reduce.
    start_production        - the start production for the grammar.
    import_list             - list of imports for use with action class.
    num_conflicts           - number of conflicts detected. 
@@ -148,10 +148,10 @@ public class emit {
   public String scan_code = null;
 
   /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
-
-  /** User code that will be inserted after every reduce call. */
+  
+  /** User code that will be called after every reduce call. */
   public String after_reduce_code = null;
-
+  
   /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
 
   /** List of imports (Strings containing class names) to go with actions. */
@@ -345,6 +345,9 @@ public class emit {
        * action code embedded in a production (ie, non-rightmost
        * action code). 24-Mar-1998 CSA
        */
+      if (after_reduce_code != null)
+  out.println("              " + RUNTIME_PACKAGE + ".Symbol[] $symbols_array = new " + 
+      RUNTIME_PACKAGE + ".Symbol[" + prod.rhs_stackdepth() + "];");
       for (int i=prod.rhs_stackdepth()-1; i>=0; i--) 
 	{
 	  symbol_part symbol = baseprod.rhs(i);
@@ -353,18 +356,11 @@ public class emit {
 	  boolean is_wildcard = !is_star_action && symtype != null
 	  	&& (symbol.the_symbol.name().endsWith("*")
 		    || symbol.the_symbol.name().endsWith("+"));
-
-	  if (i == 0) {
-            out.println("              " + RUNTIME_PACKAGE + ".Symbol " +
-                    "$first = " +
-                    stackelem(prod.rhs_stackdepth() - i, is_java15) + ";");
-	  }
-	  if (i == prod.rhs_stackdepth() - 1) {
-            out.println("              " + RUNTIME_PACKAGE + ".Symbol " +
-                    "$last = " +
-                    stackelem(prod.rhs_stackdepth() - i, is_java15) + ";");
-	  }
-
+    if (after_reduce_code != null)
+      {
+      out.println("              " + "$symbols_array[" + i +"] = " +
+          stackelem(prod.rhs_stackdepth() - i, is_java15) + ";");
+      }
 	  if (label != null)
 	    {
 	      if (i == 0)
@@ -492,9 +488,9 @@ public class emit {
 	    }
 	  leftright = ", " + leftsym + ", " + rightsym;
 	}
-    if (after_reduce_code != null) {
-       out.println(after_reduce_code);
-    }
+    /* code to call the after reduce user code */
+      if (after_reduce_code != null)
+  out.println("              "+prefix+"after_reduce(RESULT, $symbols_array);");        
 	  /* code to return lhs symbol */
 	  out.println("              return parser.getSymbolFactory().newSymbol(" + 
 	      "\"" + prod.lhs().name() +  "\", " +
@@ -593,6 +589,17 @@ public class emit {
 
       /* end of method */
       out.println("    }");
+
+      /* user supplied code for after reduce code */
+      if (after_reduce_code != null)
+      {
+        out.println();
+        out.println("    /** After reduce code */");
+        out.println("    public void "+prefix+"after_reduce(Object RESULT, "+RUNTIME_PACKAGE + ".Symbol[] symbols) throws java.lang.Exception");
+        out.println("    {");
+        out.println(after_reduce_code);
+        out.println("    }");
+      }
 
       /* end of class */
       out.println("}");

--- a/src/com/github/jhoenicke/javacup/emit.java
+++ b/src/com/github/jhoenicke/javacup/emit.java
@@ -148,10 +148,10 @@ public class emit {
   public String scan_code = null;
 
   /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
-  
+
   /** User code that will be called after every reduce call. */
   public String after_reduce_code = null;
-  
+
   /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
 
   /** List of imports (Strings containing class names) to go with actions. */
@@ -346,8 +346,9 @@ public class emit {
        * action code). 24-Mar-1998 CSA
        */
       if (after_reduce_code != null)
-  out.println("              " + RUNTIME_PACKAGE + ".Symbol[] $symbols_array = new " + 
-      RUNTIME_PACKAGE + ".Symbol[" + prod.rhs_stackdepth() + "];");
+	out.println("              " + RUNTIME_PACKAGE + ".Symbol[] " +
+		    pre("symbols_array") + " = new " +
+		    RUNTIME_PACKAGE + ".Symbol[" + prod.rhs_stackdepth() + "];");
       for (int i=prod.rhs_stackdepth()-1; i>=0; i--) 
 	{
 	  symbol_part symbol = baseprod.rhs(i);
@@ -356,11 +357,11 @@ public class emit {
 	  boolean is_wildcard = !is_star_action && symtype != null
 	  	&& (symbol.the_symbol.name().endsWith("*")
 		    || symbol.the_symbol.name().endsWith("+"));
-    if (after_reduce_code != null)
-      {
-      out.println("              " + "$symbols_array[" + i +"] = " +
-          stackelem(prod.rhs_stackdepth() - i, is_java15) + ";");
-      }
+	  if (after_reduce_code != null)
+	    {
+	      out.println("              " + pre("symbols_array") + "[" + i + "] = " +
+			  stackelem(prod.rhs_stackdepth() - i, is_java15) + ";");
+	    }
 	  if (label != null)
 	    {
 	      if (i == 0)
@@ -488,13 +489,14 @@ public class emit {
 	    }
 	  leftright = ", " + leftsym + ", " + rightsym;
 	}
-    /* code to call the after reduce user code */
+      /* code to call the after reduce user code */
       if (after_reduce_code != null)
-  out.println("              "+prefix+"after_reduce(RESULT, $symbols_array);");        
-	  /* code to return lhs symbol */
-	  out.println("              return parser.getSymbolFactory().newSymbol(" + 
-	      "\"" + prod.lhs().name() +  "\", " +
-	      prod.lhs().index() + leftright + result + ");");
+	out.println("              " + pre("after_reduce") + "(RESULT, " +
+		    pre("symbols_array") + ");");
+      /* code to return lhs symbol */
+      out.println("              return parser.getSymbolFactory().newSymbol(" +
+		  "\"" + prod.lhs().name() +  "\", " +
+		  prod.lhs().index() + leftright + result + ");");
     }
 
   /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
@@ -592,14 +594,15 @@ public class emit {
 
       /* user supplied code for after reduce code */
       if (after_reduce_code != null)
-      {
-        out.println();
-        out.println("    /** After reduce code */");
-        out.println("    public void "+prefix+"after_reduce(Object RESULT, "+RUNTIME_PACKAGE + ".Symbol[] symbols) throws java.lang.Exception");
-        out.println("    {");
-        out.println(after_reduce_code);
-        out.println("    }");
-      }
+	{
+	  out.println();
+	  out.println("    /** After reduce code */");
+	  out.println("    public void " + prefix + "after_reduce(Object RESULT, "
+		      + RUNTIME_PACKAGE + ".Symbol[] symbols) throws java.lang.Exception");
+	  out.println("    {");
+	  out.println(after_reduce_code);
+	  out.println("    }");
+	}
 
       /* end of class */
       out.println("}");

--- a/src/com/github/jhoenicke/javacup/emit.java
+++ b/src/com/github/jhoenicke/javacup/emit.java
@@ -82,6 +82,7 @@ import java.util.Date;
    init_code               - user supplied code to be executed as the parser 
 			     is being initialized.
    scan_code               - user supplied code to get the next Symbol.
+   after_reduce_code       - user code that will run after every reduce
    start_production        - the start production for the grammar.
    import_list             - list of imports for use with action class.
    num_conflicts           - number of conflicts detected. 
@@ -145,6 +146,11 @@ public class emit {
 
   /** User code for scan() which is called to get the next Symbol. */
   public String scan_code = null;
+
+  /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
+
+  /** User code that will be inserted after every reduce call. */
+  public String after_reduce_code = null;
 
   /*. . . . . . . . . . . . . . . . . . . . . . . . . . . . . .*/
 
@@ -348,6 +354,17 @@ public class emit {
 	  	&& (symbol.the_symbol.name().endsWith("*")
 		    || symbol.the_symbol.name().endsWith("+"));
 
+	  if (i == 0) {
+            out.println("              " + RUNTIME_PACKAGE + ".Symbol " +
+                    "$first = " +
+                    stackelem(prod.rhs_stackdepth() - i, is_java15) + ";");
+	  }
+	  if (i == prod.rhs_stackdepth() - 1) {
+            out.println("              " + RUNTIME_PACKAGE + ".Symbol " +
+                    "$last = " +
+                    stackelem(prod.rhs_stackdepth() - i, is_java15) + ";");
+	  }
+
 	  if (label != null)
 	    {
 	      if (i == 0)
@@ -475,6 +492,9 @@ public class emit {
 	    }
 	  leftright = ", " + leftsym + ", " + rightsym;
 	}
+    if (after_reduce_code != null) {
+       out.println(after_reduce_code);
+    }
 	  /* code to return lhs symbol */
 	  out.println("              return parser.getSymbolFactory().newSymbol(" + 
 	      "\"" + prod.lhs().name() +  "\", " +


### PR DESCRIPTION
## Features
* Added the possibility to run code after every reduce.
* Added the variables `$first` and `$last` to allow the after reduce code to easily get the line number. 

## Example usage
I'm building a compiler so this is an example from my code:
```java
after reduce {:
    int $$lineNumber = $first.left + 1;
    if (AST_Node.class.isInstance(RESULT)) {
        AST_Node ast = AST_Node.class.cast(RESULT);
        ast.lineNumber = $$lineNumber;
    } else if (AST_CALLABLE_VAR_CONT.class.isInstance(RESULT)) {
        AST_CALLABLE_VAR_CONT ast = AST_CALLABLE_VAR_CONT.class.cast(RESULT);
        ast.lineNumber = $$lineNumber;
    }
:}
```

## Notes
* Sorry about the spaces, Intellij fought me :(
* The name of the variables I created probably doesn't work well with your naming convention. 
* Didn't touch the changelog